### PR TITLE
Add --fake parameter (bug 1061143)

### DIFF
--- a/schematic
+++ b/schematic
@@ -198,7 +198,7 @@ def find_upgrades(schema_dir):
     return upgrades
 
 
-def run_upgrades(db, table, schema_dir, maximum=None, handlers={}):
+def run_upgrades(db, table, schema_dir, maximum=None, handlers={}, fake=False):
     current = get_version(db, table)
     all_upgrades = find_upgrades(schema_dir).items()
     upgrades = [(version, path) for version, path in all_upgrades
@@ -208,16 +208,21 @@ def run_upgrades(db, table, schema_dir, maximum=None, handlers={}):
             print 'Reached max version: %s' % maximum
             break
         start = time.time()
-        upgrade(db, table, version, path, handlers)
+        upgrade(db, table, version, path, handlers, fake)
         print 'That took %.2f seconds' % (time.time() - start)
         print '#' * 50, '\n'
 
 
-def upgrade(db, table, version, path, handlers):
+def upgrade(db, table, version, path, handlers, fake=False):
     extension = os.path.splitext(path)[1]
     handler = handlers.get(extension)
     update = UPDATE % (table, version)
-    if not extension or extension == '.sql':
+    if fake:
+        # We just update the version number in db, without actually
+        # running the transaction for real.
+        print 'Faking migration %s' % version
+        say(db, update)
+    elif not extension or extension == '.sql':
         sql = open(path).read()
         print 'Running SQL migration %s:\n' % version, sql
         say(db, UPGRADE % (sql, update))
@@ -234,7 +239,7 @@ def get_version(db, table):
     return int(say(db, SELECT % table))
 
 
-def main(schema_dir, maximum=None):
+def main(schema_dir, maximum=None, fake=False):
     settings = get_settings(schema_dir)
     db, table = settings.db, settings.table
 
@@ -243,7 +248,7 @@ def main(schema_dir, maximum=None):
         print 'Up to max: %s' % maximum
     run_upgrades(db, table, schema_dir, maximum,
                  getattr(settings, 'handlers',
-                         OPTIONAL_VARIABLES['handlers']))
+                         OPTIONAL_VARIABLES['handlers']), fake)
 
 
 def update(schema_dir, version):
@@ -274,6 +279,10 @@ if __name__ == '__main__':
                       action='store', type='int',
                       help='Stop running migrations after the specified '
                            'revision.')
+    parser.add_option('-F', '--fake', dest='fake', default=False,
+                      action='store_true',
+                      help='Mark migrations as run without actually running '
+                           'them')
     options, args = parser.parse_args()
 
     if len(args) != 1:
@@ -289,7 +298,7 @@ if __name__ == '__main__':
         elif options.version:
             version(path)
         else:
-            main(path, options.max)
+            main(path, options.max, options.fake)
     except SchematicError, e:
         print 'Error:', e
         sys.exit(1)


### PR DESCRIPTION
Allow to mark migrations as run without really running them. Useful for database initialization.

We need this to the Landfill replacement.

See  https://bugzilla.mozilla.org/show_bug.cgi?id=1061143 for reference.

I've chosen this implementation because it allows to still use `--max` when using `--fake`.
